### PR TITLE
visionOS XR module – (3) visionOS: Do not show boot logo in immersive mode

### DIFF
--- a/drivers/apple_embedded/godot_renderer.h
+++ b/drivers/apple_embedded/godot_renderer.h
@@ -45,5 +45,6 @@ inline void safeDispatchSyncToMain(void (^block)(void)) {
 @property(assign, readonly, nonatomic) BOOL hasFinishedSetup;
 
 - (BOOL)setUp;
+- (void)setUpProjectDataShowingBootLogo:(BOOL)p_show_boot_logo;
 
 @end

--- a/drivers/apple_embedded/godot_renderer.mm
+++ b/drivers/apple_embedded/godot_renderer.mm
@@ -55,7 +55,7 @@
 	}
 
 	if (!self.hasCalledProjectDataSetUp) {
-		[self setUpProjectData];
+		[self setUpProjectDataShowingBootLogo:YES];
 	}
 
 	if (!self.hasStartedMain) {
@@ -67,10 +67,10 @@
 	return NO;
 }
 
-- (void)setUpProjectData {
+- (void)setUpProjectDataShowingBootLogo:(BOOL)p_show_boot_logo {
 	self.hasCalledProjectDataSetUp = YES;
 	safeDispatchSyncToMain(^{
-		Main::setup2();
+		Main::setup2(p_show_boot_logo);
 
 		// this might be necessary before here
 		NSDictionary *dict = [[NSBundle mainBundle] infoDictionary];

--- a/platform/visionos/godot_compositor_services_renderer.mm
+++ b/platform/visionos/godot_compositor_services_renderer.mm
@@ -53,6 +53,12 @@ extern void apple_embedded_finish();
 	return self;
 }
 
+// Skip the boot splash in CompositorServices (immersive XR) mode.
+// There is no visible window to display it on.
+- (void)setUpProjectDataShowingBootLogo:(BOOL)p_show_boot_logo {
+	[super setUpProjectDataShowingBootLogo:NO];
+}
+
 - (void)updateXRInterface {
 	Ref<VisionOSXRInterface> visionos_xr_interface = VisionOSXRInterface::find_interface();
 	if (visionos_xr_interface.is_valid()) {


### PR DESCRIPTION
Dear Godot Community,

We are contributing visionOS support in https://github.com/godotengine/godot/pull/109975. This follow-up avoids showing the boot logo on visionOS in immersive mode, to avoid rendering errors on the first frame (there's no texture to render it to).

_Disclaimer: Claude Code was used to assist development and to refactor code. All the code was reviewed by Apple employees, and tested on real hardware before submitting._