### PR TITLE
visionOS XR module – (6) visionOS: Improve Apple embedded audio lifecycle

### DIFF
--- a/drivers/apple_embedded/godot_app_delegate_service_apple_embedded.mm
+++ b/drivers/apple_embedded/godot_app_delegate_service_apple_embedded.mm
@@ -131,10 +131,10 @@ static __weak GDTViewController *_viewController = nil;
 	if ([notification.name isEqualToString:AVAudioSessionInterruptionNotification]) {
 		if ([[notification.userInfo valueForKey:AVAudioSessionInterruptionTypeKey] isEqualToNumber:[NSNumber numberWithInt:AVAudioSessionInterruptionTypeBegan]]) {
 			NSLog(@"Audio interruption began");
-			OS_AppleEmbedded::get_singleton()->on_focus_out();
+			OS_AppleEmbedded::get_singleton()->audio_driver_stop();
 		} else if ([[notification.userInfo valueForKey:AVAudioSessionInterruptionTypeKey] isEqualToNumber:[NSNumber numberWithInt:AVAudioSessionInterruptionTypeEnded]]) {
 			NSLog(@"Audio interruption ended");
-			OS_AppleEmbedded::get_singleton()->on_focus_in();
+			OS_AppleEmbedded::get_singleton()->audio_driver_start();
 		}
 	}
 }
@@ -163,36 +163,38 @@ static __weak GDTViewController *_viewController = nil;
 	OS_AppleEmbedded::get_singleton()->on_focus_out();
 }
 
-- (void)sceneWillResignActive:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
-	OS_AppleEmbedded::get_singleton()->on_focus_out();
+- (void)sceneWillEnterForeground:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	// This method is not called on visionOS Compositor Services Immersive Scenes due to a pre-existing issue
+	OS_AppleEmbedded::get_singleton()->on_exit_background();
 }
 
 - (void)sceneDidBecomeActive:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
 	OS_AppleEmbedded::get_singleton()->on_focus_in();
 }
 
+- (void)sceneWillResignActive:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	// This method is not called on visionOS Compositor Services Immersive Scenes due to a pre-existing issue
+	OS_AppleEmbedded::get_singleton()->on_focus_out();
+}
+
 - (void)sceneDidEnterBackground:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
 	OS_AppleEmbedded::get_singleton()->on_enter_background();
 }
 
-- (void)sceneWillEnterForeground:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+- (void)applicationWillEnterForeground:(UIApplication *)application {
 	OS_AppleEmbedded::get_singleton()->on_exit_background();
-}
-
-- (void)applicationWillResignActive:(UIApplication *)application {
-	OS_AppleEmbedded::get_singleton()->on_focus_out();
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
 	OS_AppleEmbedded::get_singleton()->on_focus_in();
 }
 
-- (void)applicationDidEnterBackground:(UIApplication *)application {
-	OS_AppleEmbedded::get_singleton()->on_enter_background();
+- (void)applicationWillResignActive:(UIApplication *)application {
+	OS_AppleEmbedded::get_singleton()->on_focus_out();
 }
 
-- (void)applicationWillEnterForeground:(UIApplication *)application {
-	OS_AppleEmbedded::get_singleton()->on_exit_background();
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+	OS_AppleEmbedded::get_singleton()->on_enter_background();
 }
 
 - (void)dealloc {

--- a/drivers/apple_embedded/os_apple_embedded.h
+++ b/drivers/apple_embedded/os_apple_embedded.h
@@ -133,6 +133,9 @@ public:
 
 	virtual Error setup_remote_filesystem(const String &p_server_host, int p_port, const String &p_password, String &r_project_path) override;
 
+	void audio_driver_start();
+	void audio_driver_stop();
+
 	void on_focus_out();
 	void on_focus_in();
 

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -771,6 +771,14 @@ Error OS_AppleEmbedded::setup_remote_filesystem(const String &p_server_host, int
 	return err;
 }
 
+void OS_AppleEmbedded::audio_driver_start() {
+	audio_driver.start();
+}
+
+void OS_AppleEmbedded::audio_driver_stop() {
+	audio_driver.stop();
+}
+
 void OS_AppleEmbedded::on_focus_out() {
 	if (is_focused) {
 		is_focused = false;

--- a/platform/visionos/godot_app_delegate_service_visionos.mm
+++ b/platform/visionos/godot_app_delegate_service_visionos.mm
@@ -30,6 +30,8 @@
 
 #import "godot_app_delegate_service_visionos.h"
 
+#import "drivers/apple_embedded/os_apple_embedded.h"
+
 static GDTRenderMode _renderMode = GDTRenderModeWindowed;
 static __weak cp_layer_renderer_t _layerRenderer = nil;
 static __strong cp_layer_renderer_capabilities_t _layerRendererCapabilities = nil;
@@ -74,6 +76,19 @@ static __strong cp_layer_renderer_capabilities_t _layerRendererCapabilities = ni
 		return;
 	}
 	_layerRendererCapabilities = layerRendererCapabilities;
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	[super sceneDidBecomeActive:scene];
+
+	// On Compositor Services scenes, sceneDidBecomeActive: is called too son when
+	// donning the device, which attempts to start the audio driver too early. Start it
+	// again after a short delay so audio resumes correctly.
+	if (_renderMode == GDTRenderModeCompositorServices) {
+		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+			OS_AppleEmbedded::get_singleton()->audio_driver_start();
+		});
+	}
 }
 
 @end


### PR DESCRIPTION
Dear Godot Community,

We are contributing visionOS support in https://github.com/godotengine/godot/pull/109975.

This follow-up improves the audio session lifecycle handling on Apple embedded platforms by splitting audio driver start/stop functions that can be independently called from focus in/out.

It also works around a visionOS bug where scene lifecycle methods are called too early when taking Apple Vision Pro off and on again, resulting in no audio.

_Disclaimer: Claude Code was used to assist development and to refactor code. All the code was reviewed by Apple employees, and tested on real hardware before submitting._