### PR TITLE
visionOS XR module – (7) visionOS: Implement hand and PSVR2 controller trackers

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3664,6 +3664,12 @@
 		<member name="xr/shaders/enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], Godot will compile shaders required for XR.
 		</member>
+		<member name="xr/visionos/enable_controller_tracking" type="bool" setter="" getter="" default="false">
+			Enables and initializes visionOS controller tracking.
+		</member>
+		<member name="xr/visionos/enable_hand_tracking" type="bool" setter="" getter="" default="false">
+			Enables and initializes visionOS hand tracking.
+		</member>
 	</members>
 	<signals>
 		<signal name="settings_changed">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2906,6 +2906,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_BASIC("xr/openxr/binding_modifiers/analog_threshold", false);
 	GLOBAL_DEF_RST_BASIC("xr/openxr/binding_modifiers/dpad_binding", false);
 
+	// visionOS settings
+	GLOBAL_DEF_BASIC("xr/visionos/enable_hand_tracking", false);
+	GLOBAL_DEF_BASIC("xr/visionos/enable_controller_tracking", false);
+
 #ifdef TOOLS_ENABLED
 	// Disabled for now, using XR inside of the editor we'll be working on during the coming months.
 

--- a/misc/dist/apple_embedded_xcode/godot_apple_embedded/godot_apple_embedded-Info.plist
+++ b/misc/dist/apple_embedded_xcode/godot_apple_embedded/godot_apple_embedded-Info.plist
@@ -75,5 +75,7 @@
 			$application_scene_manifest_immersive_configuration
 		</dict>
 	</dict>
+    $hand_tracking_usage_description
+    $accessory_tracking_usage_description
 </dict>
 </plist>

--- a/modules/visionos_xr/config.py
+++ b/modules/visionos_xr/config.py
@@ -9,6 +9,8 @@ def configure(env):
 def get_doc_classes():
     return [
         "VisionOSXRInterface",
+        "VisionOSXRHandTracker",
+        "VisionOSXRControllerTracker",
     ]
 
 

--- a/modules/visionos_xr/doc_classes/VisionOSXRControllerTracker.xml
+++ b/modules/visionos_xr/doc_classes/VisionOSXRControllerTracker.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisionOSXRControllerTracker" inherits="XRInterface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		visionOS controller tracker interface.
+	</brief_description>
+	<description>
+		This is the visionOS controller tracker interface.
+
+		Uses ARKit's [code]AccessoryTrackingProvider[/code] to get controller tracking, and populates the [code]"/user/controller_tracker/left"[/code] and [code]"/user/controller_tracker/right"[/code] reserved XRController trackers.
+
+		You can enable it using the [member ProjectSettings.xr/visionos/enable_controller_tracking] project setting.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/visionos_xr/doc_classes/VisionOSXRHandTracker.xml
+++ b/modules/visionos_xr/doc_classes/VisionOSXRHandTracker.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisionOSXRHandTracker" inherits="XRInterface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		visionOS hand tracker interface.
+	</brief_description>
+	<description>
+		This is the visionOS hand tracker interface.
+
+		Uses ARKit's [code]HandTrackingProvider[/code] to get hand tracking, and populates the [code]"/user/hand_tracker/left"[/code] and [code]"/user/hand_tracker/right"[/code] reserved XRHandTrackers.
+
+		You can enable it using the [member ProjectSettings.xr/visionos/enable_hand_tracking] project setting.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/visionos_xr/register_types.mm
+++ b/modules/visionos_xr/register_types.mm
@@ -32,11 +32,15 @@
 
 #include "register_types.h"
 
+#include "visionos_xr_controller_tracker.h"
+#include "visionos_xr_hand_tracker.h"
 #include "visionos_xr_interface.h"
 
 #include "core/object/class_db.h"
 
 Ref<VisionOSXRInterface> visionos_xr;
+Ref<VisionOSXRHandTracker> visionos_hand_tracker;
+Ref<VisionOSXRControllerTracker> visionos_controller_tracker;
 
 void initialize_visionos_xr_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
@@ -44,10 +48,20 @@ void initialize_visionos_xr_module(ModuleInitializationLevel p_level) {
 	}
 
 	GDREGISTER_CLASS(VisionOSXRInterface);
+	GDREGISTER_CLASS(VisionOSXRHandTracker);
+	GDREGISTER_CLASS(VisionOSXRControllerTracker);
 
 	if (XRServer::get_singleton()) {
 		visionos_xr.instantiate();
 		XRServer::get_singleton()->add_interface(visionos_xr);
+
+		visionos_hand_tracker.instantiate();
+		visionos_hand_tracker->set_xr_interface(visionos_xr.ptr());
+		XRServer::get_singleton()->add_interface(visionos_hand_tracker);
+
+		visionos_controller_tracker.instantiate();
+		visionos_controller_tracker->set_xr_interface(visionos_xr.ptr());
+		XRServer::get_singleton()->add_interface(visionos_controller_tracker);
 	}
 }
 
@@ -56,11 +70,34 @@ void uninitialize_visionos_xr_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
+	if (visionos_controller_tracker.is_valid()) {
+		if (visionos_controller_tracker->is_initialized()) {
+			visionos_controller_tracker->uninitialize();
+		}
+		if (XRServer::get_singleton()) {
+			XRServer::get_singleton()->remove_interface(visionos_controller_tracker);
+		}
+		visionos_controller_tracker.unref();
+	}
+
+	if (visionos_hand_tracker.is_valid()) {
+		if (visionos_hand_tracker->is_initialized()) {
+			visionos_hand_tracker->uninitialize();
+		}
+		if (XRServer::get_singleton()) {
+			XRServer::get_singleton()->remove_interface(visionos_hand_tracker);
+		}
+		visionos_hand_tracker.unref();
+	}
+
 	if (visionos_xr.is_valid()) {
 		// uninitialize our interface if it is initialized
 		if (visionos_xr->is_initialized()) {
 			visionos_xr->uninitialize();
 		}
+
+		// Destroy the shared ARKit session after all interfaces are uninitialized
+		visionos_xr->destroy_session();
 
 		// unregister our interface from the XR server
 		if (XRServer::get_singleton()) {

--- a/modules/visionos_xr/visionos_xr_controller_tracker.h
+++ b/modules/visionos_xr/visionos_xr_controller_tracker.h
@@ -1,0 +1,140 @@
+/**************************************************************************/
+/*  visionos_xr_controller_tracker.h                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/templates/local_vector.h"
+#include "core/variant/variant.h"
+#ifdef VISIONOS_ENABLED
+
+#include "servers/xr/xr_controller_tracker.h"
+#include "servers/xr/xr_interface.h"
+
+#import <ARKit/ARKit.h>
+
+@class GCController;
+@class CHHapticEngine;
+
+class VisionOSXRInterface;
+
+class VisionOSXRControllerTracker : public XRInterface {
+	GDCLASS(VisionOSXRControllerTracker, XRInterface);
+
+private:
+	// Core state
+	bool initialized = false;
+	XRInterface::TrackingStatus tracking_state;
+
+	VisionOSXRInterface *xr_interface = nullptr;
+
+	// ARKit state
+	ar_accessory_tracking_provider_t controller_tracking_provider = nullptr;
+	ar_accessories_t _accessories_to_add;
+	ar_accessory_anchor_t left_controller_anchor;
+	ar_accessory_anchor_t right_controller_anchor;
+
+	// Lock for provider and accessories and controller state
+	os_unfair_lock _accessory_lock;
+
+	// Controller state
+	Ref<XRControllerTracker> left_controller_tracker;
+	Ref<XRControllerTracker> right_controller_tracker;
+	GCController *left_gc_controller = nullptr;
+	GCController *right_gc_controller = nullptr;
+	CHHapticEngine *left_haptic_engine = nullptr;
+	CHHapticEngine *right_haptic_engine = nullptr;
+
+	// Notification observers
+	id controller_observer = nullptr;
+	id controller_disconnect_observer = nullptr;
+
+	// Additional tracking correction
+	Transform3D tracking_correction;
+
+	struct Event {
+		Ref<XRControllerTracker> controller_tracker;
+		const char *action_name;
+		Variant value;
+	};
+
+	/// Buffering events to avoid re-entering the same lock (shared between events and haptics)
+	using Events = LocalVector<Event>;
+
+	void update_controller_trackers_from_arkit();
+	void update_controller_from_anchor(Ref<XRControllerTracker> controller_tracker, ar_accessory_anchor_t controller_anchor, GCController *gc_controller,
+			bool is_left_hand, Events &);
+	void setup_controller_notifications();
+	void handle_controller_disconnect(GCController *controller);
+	void cleanup_controller_notifications();
+	void init_for_controller(GCController *controller);
+	void run_provider();
+	void run_provider_locked();
+
+	struct Helpers;
+	friend Helpers;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static StringName name() { return "visionOSControllerTracker"; }
+	static Ref<VisionOSXRControllerTracker> find_interface() {
+		return XRServer::get_singleton()->find_interface(name());
+	}
+
+	VisionOSXRControllerTracker();
+	~VisionOSXRControllerTracker();
+
+	void set_xr_interface(VisionOSXRInterface *p_interface) { xr_interface = p_interface; }
+
+	virtual StringName get_name() const override;
+	virtual uint32_t get_capabilities() const override;
+	virtual TrackingStatus get_tracking_status() const override;
+
+	virtual bool is_initialized() const override;
+	virtual bool initialize() override;
+	virtual void uninitialize() override;
+	virtual Dictionary get_system_info() override;
+
+	virtual Size2 get_render_target_size() override;
+	virtual uint32_t get_view_count() override;
+
+	virtual Transform3D get_camera_transform() override;
+	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
+	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+
+	virtual void process() override;
+	virtual Vector<RenderingServerTypes::BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
+	virtual void trigger_haptic_pulse(const String &p_action_name, const StringName &p_tracker_name, double p_frequency, double p_amplitude, double p_duration_sec, double p_delay_sec = 0) override;
+
+	void set_tracking_correction(const Transform3D &p_correction);
+};
+
+#endif

--- a/modules/visionos_xr/visionos_xr_controller_tracker.mm
+++ b/modules/visionos_xr/visionos_xr_controller_tracker.mm
@@ -1,0 +1,629 @@
+/**************************************************************************/
+/*  visionos_xr_controller_tracker.mm                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef VISIONOS_ENABLED
+
+// Rename Godot's `Key` to `GodotKey` so it doesn't clash with GCPhysicalInputElementCollection's `Key` template parameter; unused in this file.
+#define Key GodotKey
+#include "visionos_xr_controller_tracker.h"
+
+#include "visionos_simd_helpers.h"
+#include "visionos_xr_interface.h"
+
+#include "core/error/error_macros.h"
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "servers/rendering/rendering_device.h"
+#include "servers/rendering/rendering_server_globals.h"
+
+#include "platform/visionos/godot_app_delegate_service_visionos.h"
+#undef Key
+
+#include <ARKit/ARKit.h>
+#include <CoreHaptics/CoreHaptics.h>
+#import <GameController/GameController.h>
+
+// Button mapping logic
+namespace {
+struct ButtonMapping {
+	GCInputButtonName gc_input;
+	const char *action_name;
+	const char *click_action_name;
+};
+
+static const ButtonMapping button_mappings[] = {
+	{ GCInputGripButton, "grip_button", "grip_button_click" },
+	{ GCInputTrigger, "trigger", "trigger_click" },
+	{ GCInputButtonA, "button_a", nullptr },
+	{ GCInputButtonB, "button_b", nullptr },
+	{ GCInputButtonMenu, "button_menu", nullptr },
+	{ GCInputThumbstickButton, "button_thumbstick", nullptr },
+};
+} //namespace
+
+struct VisionOSXRControllerTracker::Helpers {
+	static void process_button(GCControllerLiveInput *input, const ButtonMapping &button_mapping,
+			Ref<XRControllerTracker> controller_tracker, VisionOSXRControllerTracker::Events &events) {
+		auto *button = input.buttons[button_mapping.gc_input];
+		if (button != nullptr) {
+			events.push_back({ .controller_tracker = controller_tracker,
+					.action_name = button_mapping.action_name,
+					.value = button.pressedInput.value });
+			if (button_mapping.click_action_name != nullptr) {
+				events.push_back({ .controller_tracker = controller_tracker,
+						.action_name = button_mapping.click_action_name,
+						.value = button.pressedInput.isPressed });
+			}
+		}
+	}
+
+	static void process_thumbstick(GCControllerLiveInput *input, Ref<XRControllerTracker> controller_tracker,
+			VisionOSXRControllerTracker::Events &events) {
+		auto *thumbstick = input.dpads[GCInputThumbstick];
+		if (thumbstick != nullptr) {
+			float x_value = thumbstick.xAxis.value;
+			float y_value = thumbstick.yAxis.value;
+			events.push_back({ .controller_tracker = controller_tracker,
+					.action_name = "primary",
+					.value = Vector2(x_value, y_value) });
+		}
+	}
+};
+
+VisionOSXRControllerTracker::VisionOSXRControllerTracker() {}
+
+void VisionOSXRControllerTracker::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_tracking_correction", "correction"), &VisionOSXRControllerTracker::set_tracking_correction);
+}
+
+VisionOSXRControllerTracker::~VisionOSXRControllerTracker() {
+	// and make sure we cleanup if we haven't already
+	if (is_initialized()) {
+		uninitialize();
+	};
+}
+
+StringName VisionOSXRControllerTracker::get_name() const {
+	return VisionOSXRControllerTracker::name();
+}
+
+uint32_t VisionOSXRControllerTracker::get_capabilities() const {
+	return XRInterface::XR_NONE;
+}
+
+uint32_t VisionOSXRControllerTracker::get_view_count() {
+	return 0;
+}
+
+XRInterface::TrackingStatus VisionOSXRControllerTracker::get_tracking_status() const {
+	return tracking_state;
+}
+
+bool VisionOSXRControllerTracker::is_initialized() const {
+	return initialized;
+}
+
+bool VisionOSXRControllerTracker::initialize() {
+	if (initialized) {
+		ERR_PRINT("VisionOSXRControllerTracker already initialized");
+		return true;
+	}
+
+	ERR_FAIL_NULL_V_MSG(xr_interface, false, "VisionOSXRControllerTracker: xr_interface not set.");
+
+	// Ensure the shared ARKit session exists (idempotent), so this tracker can be
+	// initialized standalone from GDScript without the compositor services renderer.
+	xr_interface->ensure_session();
+
+	_accessory_lock = OS_UNFAIR_LOCK_INIT;
+	_accessories_to_add = ar_accessories_create();
+
+	// Scan existing controllers
+	for (GCController *controller in GCController.controllers) {
+		init_for_controller(controller);
+	}
+
+	setup_controller_notifications();
+
+	ar_session_t shared_session = xr_interface->get_ar_session();
+	ERR_FAIL_NULL_V_MSG(shared_session, false, "VisionOSXRControllerTracker: shared ARKit session not available.");
+
+	ar_session_request_authorization(shared_session, ar_authorization_type_accessory_tracking,
+			^(ar_authorization_results_t authorization_results, ar_error_t error) {
+				if (error) {
+					ERR_PRINT("VisionOSXRControllerTracker : Error requesting Accessory Tracking authorization.");
+					return;
+				}
+
+				ar_authorization_results_enumerate_results(authorization_results,
+						^bool(ar_authorization_result_t authorization_result) {
+							if (ar_authorization_result_get_authorization_type(authorization_result) & ar_authorization_type_accessory_tracking) {
+								switch (ar_authorization_result_get_status(authorization_result)) {
+									case ar_authorization_status_denied:
+										ERR_PRINT("VisionOSXRControllerTracker : Accessory Tracking authorization has been denied...");
+										break;
+									case ar_authorization_status_allowed:
+										break;
+									default:
+										break;
+								}
+							}
+							return true;
+						});
+			});
+
+	left_controller_tracker.instantiate();
+	left_controller_tracker->set_tracker_hand(XRPositionalTracker::TRACKER_HAND_LEFT);
+	left_controller_tracker->set_tracker_name("/user/controller_tracker/left");
+	left_controller_tracker->set_tracker_desc("VisionOS Left Controller");
+	XRServer::get_singleton()->add_tracker(left_controller_tracker);
+
+	right_controller_tracker.instantiate();
+	right_controller_tracker->set_tracker_hand(XRPositionalTracker::TRACKER_HAND_RIGHT);
+	right_controller_tracker->set_tracker_name("/user/controller_tracker/right");
+	right_controller_tracker->set_tracker_desc("VisionOS Right Controller");
+	XRServer::get_singleton()->add_tracker(right_controller_tracker);
+
+	initialized = true;
+	return initialized;
+}
+
+void VisionOSXRControllerTracker::uninitialize() {
+	os_unfair_lock_lock(&_accessory_lock);
+
+	if (!initialized) {
+		os_unfair_lock_unlock(&_accessory_lock);
+		return;
+	}
+
+	// Remove our controller tracking provider from the shared session
+	if (controller_tracking_provider != nullptr && xr_interface != nullptr) {
+		xr_interface->remove_data_provider(controller_tracking_provider);
+		controller_tracking_provider = nullptr;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	if (xr_server != nullptr) {
+		if (left_controller_tracker.is_valid()) {
+			xr_server->remove_tracker(left_controller_tracker);
+			left_controller_tracker.unref();
+		}
+		if (right_controller_tracker.is_valid()) {
+			xr_server->remove_tracker(right_controller_tracker);
+			right_controller_tracker.unref();
+		}
+		initialized = false;
+	}
+
+	if (_accessories_to_add != nullptr) {
+		// Release the accessories collection if needed
+		_accessories_to_add = nullptr;
+	}
+
+	left_controller_anchor = nullptr;
+	right_controller_anchor = nullptr;
+	left_gc_controller = nullptr;
+	right_gc_controller = nullptr;
+	left_haptic_engine = nullptr;
+	right_haptic_engine = nullptr;
+
+	os_unfair_lock_unlock(&_accessory_lock);
+
+	cleanup_controller_notifications();
+}
+
+void VisionOSXRControllerTracker::run_provider() {
+	os_unfair_lock_lock(&_accessory_lock);
+	run_provider_locked();
+	os_unfair_lock_unlock(&_accessory_lock);
+}
+
+void VisionOSXRControllerTracker::run_provider_locked() {
+	if (!initialized || xr_interface == nullptr) {
+		return;
+	}
+
+	// Remove old provider from the shared session if any
+	if (controller_tracking_provider != nullptr) {
+		xr_interface->remove_data_provider(controller_tracking_provider);
+		controller_tracking_provider = nullptr;
+	}
+
+	ar_accessory_tracking_configuration_t accessory_tracking_configuration = ar_accessory_tracking_configuration_create();
+
+	if (ar_accessory_tracking_provider_is_supported() && _accessories_to_add != nullptr && ar_accessories_get_count(_accessories_to_add) != 0) {
+		ar_accessories_t accessories = ar_accessories_create();
+		ar_accessories_add_accessories(accessories, _accessories_to_add);
+		ar_accessory_tracking_configuration_set_accessories(accessory_tracking_configuration, _accessories_to_add);
+	}
+
+	controller_tracking_provider = ar_accessory_tracking_provider_create(accessory_tracking_configuration);
+	xr_interface->add_data_provider(controller_tracking_provider);
+}
+
+void VisionOSXRControllerTracker::init_for_controller(GCController *controller) {
+	ar_accessory_load_from_device(controller,
+			^(id<GCDevice> _Nonnull device, bool success, ar_error_t _Nullable error, ar_accessory_t _Nullable accessory) {
+				if (!success) {
+					ERR_PRINT("Error loading from GCDevice...\n");
+				} else {
+					os_unfair_lock_lock(&_accessory_lock);
+					ar_accessory_chirality_t chirality = ar_accessory_get_inherent_chirality(accessory);
+					if (chirality == ar_accessory_chirality_left) {
+						left_gc_controller = controller;
+						if (left_gc_controller != nullptr && left_gc_controller.haptics != nullptr) {
+							left_haptic_engine = [left_gc_controller.haptics createEngineWithLocality:GCHapticsLocalityDefault];
+						}
+						ar_accessories_add_accessory(_accessories_to_add, accessory);
+					} else if (chirality == ar_accessory_chirality_right) {
+						right_gc_controller = controller;
+						if (right_gc_controller != nullptr && right_gc_controller.haptics != nullptr) {
+							right_haptic_engine = [right_gc_controller.haptics createEngineWithLocality:GCHapticsLocalityDefault];
+						}
+						ar_accessories_add_accessory(_accessories_to_add, accessory);
+					} else {
+						ERR_PRINT("Accessory with undefined chirality...");
+					}
+					os_unfair_lock_unlock(&_accessory_lock);
+					run_provider();
+				}
+			});
+}
+
+void VisionOSXRControllerTracker::setup_controller_notifications() {
+	controller_observer = [NSNotificationCenter.defaultCenter
+			addObserverForName:GCControllerDidConnectNotification
+						object:nil
+						 queue:nil
+					usingBlock:^(NSNotification *notification) {
+						GCController *controller = (GCController *)notification.object;
+						init_for_controller(controller);
+					}];
+
+	controller_disconnect_observer = [NSNotificationCenter.defaultCenter
+			addObserverForName:GCControllerDidDisconnectNotification
+						object:nil
+						 queue:nil
+					usingBlock:^(NSNotification *notification) {
+						GCController *controller = (GCController *)notification.object;
+						handle_controller_disconnect(controller);
+					}];
+}
+
+void VisionOSXRControllerTracker::handle_controller_disconnect(GCController *controller) {
+	os_unfair_lock_lock(&_accessory_lock);
+
+	if (left_gc_controller != nullptr && left_gc_controller == controller) {
+		if (left_controller_anchor != nullptr) {
+			ar_accessory_t accessory_left = ar_accessory_anchor_get_accessory(left_controller_anchor);
+			if (accessory_left != nullptr) {
+				ar_accessories_remove_accessory(_accessories_to_add, accessory_left);
+				left_controller_anchor = nullptr;
+				left_gc_controller = nullptr;
+				left_haptic_engine = nullptr;
+				run_provider_locked();
+			}
+		}
+	} else if (right_gc_controller != nullptr && right_gc_controller == controller) {
+		if (right_controller_anchor != nullptr) {
+			ar_accessory_t accessory_right = ar_accessory_anchor_get_accessory(right_controller_anchor);
+			if (accessory_right != nullptr) {
+				ar_accessories_remove_accessory(_accessories_to_add, accessory_right);
+				right_controller_anchor = nullptr;
+				right_gc_controller = nullptr;
+				right_haptic_engine = nullptr;
+				run_provider_locked();
+			}
+		}
+	}
+
+	os_unfair_lock_unlock(&_accessory_lock);
+}
+
+void VisionOSXRControllerTracker::cleanup_controller_notifications() {
+	if (controller_observer) {
+		[NSNotificationCenter.defaultCenter removeObserver:controller_observer];
+		controller_observer = nullptr;
+	}
+
+	if (controller_disconnect_observer) {
+		[NSNotificationCenter.defaultCenter removeObserver:controller_disconnect_observer];
+		controller_disconnect_observer = nullptr;
+	}
+}
+
+Dictionary VisionOSXRControllerTracker::get_system_info() {
+	Dictionary dict;
+	dict[SNAME("XRRuntimeName")] = String("Godot visionOS Controller Tracker");
+	dict[SNAME("XRRuntimeVersion")] = String("1.0");
+	return dict;
+}
+
+Transform3D VisionOSXRControllerTracker::get_camera_transform() {
+	return Transform3D();
+}
+
+Transform3D VisionOSXRControllerTracker::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
+	return Transform3D();
+}
+
+Projection VisionOSXRControllerTracker::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
+	return Projection();
+}
+
+Size2 VisionOSXRControllerTracker::get_render_target_size() {
+	return Size2();
+}
+
+void VisionOSXRControllerTracker::update_controller_from_anchor(Ref<XRControllerTracker> controller_tracker,
+		ar_accessory_anchor_t controller_anchor,
+		GCController *gc_controller,
+		bool is_left_hand,
+		VisionOSXRControllerTracker::Events &events) {
+	simd_float4x4 origin_from_controller_anchor_simd = ar_anchor_get_origin_from_anchor_transform(controller_anchor);
+	Transform3D origin_from_controller_anchor = MTL::simd_to_transform3D(origin_from_controller_anchor_simd);
+
+	// Apply coordinate system conversion from ARKit space to Godot humanoid space
+	real_t rotation_angle = (is_left_hand ? -1 : 1) * Math::PI * 0.5;
+	const Quaternion rotation_x(Vector3(1, 0, 0), rotation_angle);
+	const Quaternion rotation_y(Vector3(0, 1, 0), rotation_angle);
+	const Quaternion controller_position_axis_adjustment = rotation_x * rotation_y;
+	origin_from_controller_anchor.basis = origin_from_controller_anchor.basis * controller_position_axis_adjustment;
+
+	origin_from_controller_anchor.origin =
+			tracking_correction.basis.xform(origin_from_controller_anchor.origin) + tracking_correction.origin;
+	Quaternion correction_rot = tracking_correction.basis.get_rotation_quaternion();
+	origin_from_controller_anchor.basis = Basis(correction_rot) * origin_from_controller_anchor.basis;
+
+	controller_tracker->set_pose("default", origin_from_controller_anchor, Vector3(), Vector3());
+
+	// Button inputs
+	if (gc_controller && gc_controller.input) {
+		GCControllerLiveInput *input = gc_controller.input;
+
+		for (const auto &mapping : button_mappings) {
+			Helpers::process_button(input, mapping, controller_tracker, events);
+		}
+		Helpers::process_thumbstick(input, controller_tracker, events);
+	}
+}
+
+void VisionOSXRControllerTracker::trigger_haptic_pulse(const String &p_action_name, const StringName &p_tracker_name, double p_frequency, double p_amplitude, double p_duration_sec, double p_delay_sec) {
+	os_unfair_lock_lock(&_accessory_lock);
+
+	GCController *target_controller = nullptr;
+	CHHapticEngine *target_engine = nullptr;
+
+	if (p_tracker_name == left_controller_tracker->get_tracker_name()) {
+		target_controller = left_gc_controller;
+		target_engine = left_haptic_engine;
+	} else if (p_tracker_name == right_controller_tracker->get_tracker_name()) {
+		target_controller = right_gc_controller;
+		target_engine = right_haptic_engine;
+	}
+
+	if (target_controller == nullptr) {
+		ERR_PRINT("Controller is nil. No haptics supported..");
+		os_unfair_lock_unlock(&_accessory_lock);
+		return;
+	}
+
+	if (target_engine == nullptr) {
+		ERR_PRINT("Haptic engine is nil...");
+		os_unfair_lock_unlock(&_accessory_lock);
+		return;
+	}
+
+	float intensity = CLAMP(p_amplitude, 0.0f, 1.0f);
+	float sharpness = CLAMP(p_frequency / 1000.0f, 0.0f, 1.0f);
+
+	NSError *error = nil;
+
+	[target_engine startAndReturnError:&error];
+	if (error) {
+		ERR_PRINT(vformat("Failed to start engine: %s", [error.localizedDescription UTF8String]));
+		os_unfair_lock_unlock(&_accessory_lock);
+		return;
+	}
+
+	CHHapticEventParameter *intensityParam = [[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticIntensity value:intensity];
+	CHHapticEventParameter *sharpnessParam = [[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticSharpness value:sharpness];
+
+	CHHapticEvent *event;
+	if (p_duration_sec > 0) {
+		event = [[CHHapticEvent alloc]
+				initWithEventType:CHHapticEventTypeHapticContinuous
+					   parameters:@[ intensityParam, sharpnessParam ]
+					 relativeTime:0.0
+						 duration:p_duration_sec];
+	} else {
+		event = [[CHHapticEvent alloc]
+				initWithEventType:CHHapticEventTypeHapticTransient
+					   parameters:@[ intensityParam, sharpnessParam ]
+					 relativeTime:0.0];
+	}
+
+	CHHapticPattern *pattern = [[CHHapticPattern alloc]
+			 initWithEvents:@[ event ]
+			parameterCurves:@[]
+					  error:&error];
+
+	if (error) {
+		ERR_PRINT(vformat("Failed to create a haptics pattern: %s", [error.localizedDescription UTF8String]));
+		os_unfair_lock_unlock(&_accessory_lock);
+		return;
+	}
+
+	id<CHHapticPatternPlayer> player = [target_engine createPlayerWithPattern:pattern error:&error];
+	if (error) {
+		ERR_PRINT(vformat("Failed to create a haptics player: %s", [error.localizedDescription UTF8String]));
+		os_unfair_lock_unlock(&_accessory_lock);
+		return;
+	}
+
+	[player startAtTime:CHHapticTimeImmediate error:&error];
+	if (error) {
+		ERR_PRINT(vformat("Failed to start a haptics playback: %s", [error.localizedDescription UTF8String]));
+	}
+
+	// For transient events, we can stop the engine immediately after starting playback
+	if (p_duration_sec <= 0) {
+		// Transient - can stop engine soon after
+		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+			[target_engine stopWithCompletionHandler:^(NSError *_Nullable error) {
+				if (error) {
+					ERR_PRINT(vformat("Error stopping haptics engine: %s", [error.localizedDescription UTF8String]));
+				}
+			}];
+		});
+	} else {
+		// Continuous - stop after duration + small buffer
+		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((p_duration_sec + 0.1) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+			[target_engine stopWithCompletionHandler:^(NSError *_Nullable error) {
+				if (error) {
+					ERR_PRINT(vformat("Error stopping haptics engine: %s", [error.localizedDescription UTF8String]));
+				}
+			}];
+		});
+	}
+
+	os_unfair_lock_unlock(&_accessory_lock);
+}
+
+void VisionOSXRControllerTracker::update_controller_trackers_from_arkit() {
+	if (!initialized) {
+		return;
+	}
+
+	if (!os_unfair_lock_trylock(&_accessory_lock)) {
+		// give up on this frame!
+		return;
+	}
+
+	// Get timing information
+	CFTimeInterval trackable_anchor_time = 0;
+
+	GDTRenderMode app_delegate_render_mode = GDTAppDelegateServiceVisionOS.renderMode;
+	if (app_delegate_render_mode == GDTRenderModeCompositorServices) {
+		if (xr_interface != nullptr && xr_interface->is_initialized()) {
+			cp_frame_timing_t frame_timing = xr_interface->get_current_timing();
+			if (frame_timing != nullptr) {
+				trackable_anchor_time = cp_time_to_cf_time_interval(cp_frame_timing_get_trackable_anchor_time(frame_timing));
+			}
+		}
+	} else {
+		// Get timing from UIScene for standalone mode
+		UIWindowScene *windowScene = nil;
+		for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+			if ([scene isKindOfClass:[UIWindowScene class]]) {
+				UIWindowScene *windowSceneCandidate = (UIWindowScene *)scene;
+				if (windowSceneCandidate.activationState == UISceneActivationStateForegroundActive) {
+					windowScene = windowSceneCandidate;
+					break;
+				}
+			}
+		}
+		if (windowScene != nil) {
+			UIUpdateInfo *ui_update_info = [UIUpdateInfo currentUpdateInfoForWindowScene:windowScene];
+			trackable_anchor_time = ui_update_info.estimatedPresentationTime;
+		}
+	}
+
+	__block Events events;
+
+	if (controller_tracking_provider != nullptr) {
+		ar_accessory_anchors_t accessory_anchors = ar_accessory_tracking_provider_get_latest_anchors(controller_tracking_provider);
+
+		__block bool left_found = false;
+		__block bool right_found = false;
+
+		if (accessory_anchors != nullptr) {
+			ar_accessory_anchors_enumerate_anchors(accessory_anchors, ^bool(ar_accessory_anchor_t accessory_anchor) {
+				ar_data_provider_state_t provider_state = ar_data_provider_get_state((ar_data_provider_t)controller_tracking_provider);
+				if (provider_state != ar_data_provider_state_running) {
+					return true;
+				}
+
+				if (!ar_trackable_anchor_is_tracked(accessory_anchor)) {
+					return true;
+				}
+
+				// Predict anchor at target time if we have timing info
+				if (trackable_anchor_time != 0) {
+					bool success = ar_accessory_tracking_provider_predict_anchor_at_timestamp(
+							controller_tracking_provider, accessory_anchor, trackable_anchor_time, accessory_anchor);
+					if (!success) {
+						return true;
+					}
+				}
+
+				ar_accessory_t accessory = ar_accessory_anchor_get_accessory(accessory_anchor);
+				ar_accessory_chirality_t chirality = ar_accessory_get_inherent_chirality(accessory);
+
+				if (chirality == ar_accessory_chirality_left && !left_found) {
+					left_controller_anchor = accessory_anchor;
+					update_controller_from_anchor(left_controller_tracker, left_controller_anchor, left_gc_controller, true, events);
+					left_found = true;
+				} else if (chirality == ar_accessory_chirality_right && !right_found) {
+					right_controller_anchor = accessory_anchor;
+					update_controller_from_anchor(right_controller_tracker, right_controller_anchor, right_gc_controller, false, events);
+					right_found = true;
+				}
+				return true;
+			});
+		}
+		tracking_state = (left_found || right_found) ? XRInterface::XR_NORMAL_TRACKING : XRInterface::XR_NOT_TRACKING;
+	}
+
+	os_unfair_lock_unlock(&_accessory_lock);
+
+	// Processing events outside of the lock, to avoid re-entering the lock
+	for (VisionOSXRControllerTracker::Event &event : events) {
+		event.controller_tracker->set_input(event.action_name, event.value);
+	}
+}
+
+void VisionOSXRControllerTracker::process() {
+	if (!initialized) {
+		return;
+	}
+	update_controller_trackers_from_arkit();
+}
+
+Vector<RenderingServerTypes::BlitToScreen> VisionOSXRControllerTracker::post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) {
+	_THREAD_SAFE_METHOD_
+	return Vector<RenderingServerTypes::BlitToScreen>();
+}
+
+void VisionOSXRControllerTracker::set_tracking_correction(const Transform3D &p_correction) {
+	tracking_correction = p_correction;
+}
+
+#endif // VISIONOS_ENABLED

--- a/modules/visionos_xr/visionos_xr_hand_tracker.h
+++ b/modules/visionos_xr/visionos_xr_hand_tracker.h
@@ -1,0 +1,159 @@
+/**************************************************************************/
+/*  visionos_xr_hand_tracker.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef VISIONOS_ENABLED
+
+#include "drivers/metal/rendering_context_driver_metal.h"
+#include "drivers/metal/rendering_device_driver_metal.h"
+#include "servers/xr/xr_hand_tracker.h"
+#include "servers/xr/xr_interface.h"
+#include "servers/xr/xr_positional_tracker.h"
+#include "servers/xr/xr_vrs.h"
+
+#import <ARKit/ARKit.h>
+#import <CompositorServices/CompositorServices.h>
+
+class VisionOSXRInterface;
+
+class VisionOSXRHandTracker : public XRInterface {
+	GDCLASS(VisionOSXRHandTracker, XRInterface);
+
+private:
+	bool initialized = false;
+	XRInterface::TrackingStatus tracking_state;
+	ar_hand_tracking_provider_t hand_tracking_provider = nullptr;
+
+	VisionOSXRInterface *xr_interface = nullptr;
+
+	// Hand trackers
+	Ref<XRHandTracker> left_hand_tracker;
+	Ref<XRHandTracker> right_hand_tracker;
+	ar_hand_anchor_t left_hand_anchor;
+	ar_hand_anchor_t right_hand_anchor;
+
+	void update_hand_trackers_from_arkit();
+	void reset_hand_tracker_data(Ref<XRHandTracker> hand_tracker);
+	void set_hand_tracker_data_from_arkit(Ref<XRHandTracker> hand_tracker, ar_hand_anchor_t hand_anchor);
+
+public:
+	static StringName name() { return "visionOSHandTracker"; }
+	static Ref<VisionOSXRHandTracker> find_interface() {
+		return XRServer::get_singleton()->find_interface(name());
+	}
+
+	VisionOSXRHandTracker();
+	~VisionOSXRHandTracker();
+
+	void set_xr_interface(VisionOSXRInterface *p_interface) { xr_interface = p_interface; }
+
+	virtual StringName get_name() const override;
+	virtual uint32_t get_capabilities() const override;
+
+	virtual TrackingStatus get_tracking_status() const override;
+
+	virtual bool is_initialized() const override;
+	virtual bool initialize() override;
+	virtual void uninitialize() override;
+	virtual Dictionary get_system_info() override;
+
+	virtual Size2 get_render_target_size() override;
+	virtual uint32_t get_view_count() override;
+
+	virtual Transform3D get_camera_transform() override;
+	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
+	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+
+	virtual void process() override;
+	virtual Vector<RenderingServerTypes::BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
+
+	_FORCE_INLINE_ static XRHandTracker::HandJoint joint_from_arkit(ar_hand_skeleton_joint_name_t joint_name) {
+		switch (joint_name) {
+			case ar_hand_skeleton_joint_name_wrist:
+				return XRHandTracker::HAND_JOINT_WRIST;
+			case ar_hand_skeleton_joint_name_thumb_knuckle:
+				return XRHandTracker::HAND_JOINT_THUMB_METACARPAL;
+			case ar_hand_skeleton_joint_name_thumb_intermediate_base:
+				return XRHandTracker::HAND_JOINT_THUMB_PHALANX_PROXIMAL;
+			case ar_hand_skeleton_joint_name_thumb_intermediate_tip:
+				return XRHandTracker::HAND_JOINT_THUMB_PHALANX_DISTAL;
+			case ar_hand_skeleton_joint_name_thumb_tip:
+				return XRHandTracker::HAND_JOINT_THUMB_TIP;
+			case ar_hand_skeleton_joint_name_index_finger_metacarpal:
+				return XRHandTracker::HAND_JOINT_INDEX_FINGER_METACARPAL;
+			case ar_hand_skeleton_joint_name_index_finger_knuckle:
+				return XRHandTracker::HAND_JOINT_INDEX_FINGER_PHALANX_PROXIMAL;
+			case ar_hand_skeleton_joint_name_index_finger_intermediate_base:
+				return XRHandTracker::HAND_JOINT_INDEX_FINGER_PHALANX_INTERMEDIATE;
+			case ar_hand_skeleton_joint_name_index_finger_intermediate_tip:
+				return XRHandTracker::HAND_JOINT_INDEX_FINGER_PHALANX_DISTAL;
+			case ar_hand_skeleton_joint_name_index_finger_tip:
+				return XRHandTracker::HAND_JOINT_INDEX_FINGER_TIP;
+			case ar_hand_skeleton_joint_name_middle_finger_metacarpal:
+				return XRHandTracker::HAND_JOINT_MIDDLE_FINGER_METACARPAL;
+			case ar_hand_skeleton_joint_name_middle_finger_knuckle:
+				return XRHandTracker::HAND_JOINT_MIDDLE_FINGER_PHALANX_PROXIMAL;
+			case ar_hand_skeleton_joint_name_middle_finger_intermediate_base:
+				return XRHandTracker::HAND_JOINT_MIDDLE_FINGER_PHALANX_INTERMEDIATE;
+			case ar_hand_skeleton_joint_name_middle_finger_intermediate_tip:
+				return XRHandTracker::HAND_JOINT_MIDDLE_FINGER_PHALANX_DISTAL;
+			case ar_hand_skeleton_joint_name_middle_finger_tip:
+				return XRHandTracker::HAND_JOINT_MIDDLE_FINGER_TIP;
+			case ar_hand_skeleton_joint_name_ring_finger_metacarpal:
+				return XRHandTracker::HAND_JOINT_RING_FINGER_METACARPAL;
+			case ar_hand_skeleton_joint_name_ring_finger_knuckle:
+				return XRHandTracker::HAND_JOINT_RING_FINGER_PHALANX_PROXIMAL;
+			case ar_hand_skeleton_joint_name_ring_finger_intermediate_base:
+				return XRHandTracker::HAND_JOINT_RING_FINGER_PHALANX_INTERMEDIATE;
+			case ar_hand_skeleton_joint_name_ring_finger_intermediate_tip:
+				return XRHandTracker::HAND_JOINT_RING_FINGER_PHALANX_DISTAL;
+			case ar_hand_skeleton_joint_name_ring_finger_tip:
+				return XRHandTracker::HAND_JOINT_RING_FINGER_TIP;
+			case ar_hand_skeleton_joint_name_little_finger_metacarpal:
+				return XRHandTracker::HAND_JOINT_PINKY_FINGER_METACARPAL;
+			case ar_hand_skeleton_joint_name_little_finger_knuckle:
+				return XRHandTracker::HAND_JOINT_PINKY_FINGER_PHALANX_PROXIMAL;
+			case ar_hand_skeleton_joint_name_little_finger_intermediate_base:
+				return XRHandTracker::HAND_JOINT_PINKY_FINGER_PHALANX_INTERMEDIATE;
+			case ar_hand_skeleton_joint_name_little_finger_intermediate_tip:
+				return XRHandTracker::HAND_JOINT_PINKY_FINGER_PHALANX_DISTAL;
+			case ar_hand_skeleton_joint_name_little_finger_tip:
+				return XRHandTracker::HAND_JOINT_PINKY_FINGER_TIP;
+			case ar_hand_skeleton_joint_name_forearm_wrist:
+			case ar_hand_skeleton_joint_name_forearm_arm:
+			default:
+				// These don't have direct equivalents or are invalid
+				return XRHandTracker::HAND_JOINT_MAX;
+		}
+	}
+};
+
+#endif

--- a/modules/visionos_xr/visionos_xr_hand_tracker.mm
+++ b/modules/visionos_xr/visionos_xr_hand_tracker.mm
@@ -1,0 +1,303 @@
+/**************************************************************************/
+/*  visionos_xr_hand_tracker.mm                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef VISIONOS_ENABLED
+
+#include "visionos_xr_hand_tracker.h"
+
+#include "visionos_simd_helpers.h"
+#include "visionos_xr_interface.h"
+
+#include "core/input/input.h"
+#include "core/os/os.h"
+#include "servers/rendering/rendering_device.h"
+#include "servers/rendering/rendering_server_globals.h"
+
+#include "platform/visionos/godot_app_delegate_service_visionos.h"
+
+VisionOSXRHandTracker::VisionOSXRHandTracker() {}
+
+VisionOSXRHandTracker::~VisionOSXRHandTracker() {
+	// and make sure we cleanup if we haven't already
+	if (is_initialized()) {
+		uninitialize();
+	};
+}
+
+StringName VisionOSXRHandTracker::get_name() const {
+	return VisionOSXRHandTracker::name();
+}
+
+uint32_t VisionOSXRHandTracker::get_capabilities() const {
+	return XRInterface::XR_NONE;
+}
+
+uint32_t VisionOSXRHandTracker::get_view_count() {
+	return 0;
+}
+
+XRInterface::TrackingStatus VisionOSXRHandTracker::get_tracking_status() const {
+	return tracking_state;
+}
+
+bool VisionOSXRHandTracker::is_initialized() const {
+	return initialized;
+}
+
+bool VisionOSXRHandTracker::initialize() {
+	print_verbose("VisionOSXRHandTracker.initialize()");
+
+	if (initialized) {
+		ERR_PRINT("VisionOSXRHandTracker already initialized");
+		return true;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	ERR_FAIL_NULL_V(xr_server, false);
+
+	ERR_FAIL_NULL_V_MSG(xr_interface, false, "VisionOSXRHandTracker: xr_interface not set.");
+
+	// Ensure the shared ARKit session exists (idempotent), so this tracker can be
+	// initialized standalone from GDScript without the compositor services renderer.
+	xr_interface->ensure_session();
+
+	// Hand tracking provider (registered with the shared ARKit session)
+	ar_hand_tracking_configuration_t hand_tracking_configuration = ar_hand_tracking_configuration_create();
+	hand_tracking_provider = ar_hand_tracking_provider_create(hand_tracking_configuration);
+	xr_interface->add_data_provider(hand_tracking_provider);
+
+	// Hand tracker initialization
+	left_hand_tracker.instantiate();
+	left_hand_tracker->set_tracker_hand(XRPositionalTracker::TRACKER_HAND_LEFT);
+	left_hand_tracker->set_tracker_name("/user/hand_tracker/left");
+	XRServer::get_singleton()->add_tracker(left_hand_tracker);
+
+	right_hand_tracker.instantiate();
+	right_hand_tracker->set_tracker_hand(XRPositionalTracker::TRACKER_HAND_RIGHT);
+	right_hand_tracker->set_tracker_name("/user/hand_tracker/right");
+	XRServer::get_singleton()->add_tracker(right_hand_tracker);
+
+	left_hand_anchor = ar_hand_anchor_create();
+	right_hand_anchor = ar_hand_anchor_create();
+
+	initialized = true;
+	return initialized;
+}
+
+void VisionOSXRHandTracker::uninitialize() {
+	if (!initialized) {
+		return;
+	}
+
+	// Remove our hand tracking provider from the shared session
+	if (hand_tracking_provider != nullptr && xr_interface != nullptr) {
+		xr_interface->remove_data_provider(hand_tracking_provider);
+		hand_tracking_provider = nullptr;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	if (xr_server != nullptr) {
+		if (left_hand_tracker.is_valid()) {
+			xr_server->remove_tracker(left_hand_tracker);
+			left_hand_tracker.unref();
+		}
+		if (right_hand_tracker.is_valid()) {
+			xr_server->remove_tracker(right_hand_tracker);
+			right_hand_tracker.unref();
+		}
+		initialized = false;
+	}
+}
+
+Dictionary VisionOSXRHandTracker::get_system_info() {
+	Dictionary dict;
+
+	dict[SNAME("XRRuntimeName")] = String("Godot visionOS Hand Tracker");
+	dict[SNAME("XRRuntimeVersion")] = String("1.0");
+
+	return dict;
+}
+
+Transform3D VisionOSXRHandTracker::get_camera_transform() {
+	return Transform3D();
+}
+
+Transform3D VisionOSXRHandTracker::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
+	return Transform3D();
+}
+
+Projection VisionOSXRHandTracker::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
+	return Projection();
+}
+
+Size2 VisionOSXRHandTracker::get_render_target_size() {
+	return Size2();
+}
+
+void VisionOSXRHandTracker::reset_hand_tracker_data(Ref<XRHandTracker> hand_tracker) {
+	hand_tracker->set_hand_tracking_source(XRHandTracker::HAND_TRACKING_SOURCE_UNKNOWN);
+	hand_tracker->set_has_tracking_data(false);
+	hand_tracker->invalidate_pose("default");
+}
+
+void VisionOSXRHandTracker::set_hand_tracker_data_from_arkit(Ref<XRHandTracker> hand_tracker, ar_hand_anchor_t hand_anchor) {
+	simd_float4x4 origin_from_hand_anchor_simd = ar_hand_anchor_get_origin_from_anchor_transform(hand_anchor);
+
+	ar_hand_skeleton_t hand_skeleton = ar_hand_anchor_get_hand_skeleton(hand_anchor);
+	Transform3D origin_from_hand_anchor = MTL::simd_to_transform3D(origin_from_hand_anchor_simd);
+
+	// Rotate from ARKit coordinates to Godot Humanoid coordinates
+	Transform3D origin_from_hand_anchor_adjusted = origin_from_hand_anchor;
+	ar_hand_chirality_t chirality = ar_hand_anchor_get_chirality(hand_anchor);
+	bool isLeftHand = (chirality == ar_hand_chirality_left);
+	real_t rotationAngle = (isLeftHand ? -1 : 1) * Math::PI * 0.5;
+	const Quaternion rotationX(Vector3(1, 0, 0), rotationAngle);
+	const Quaternion rotationY(Vector3(0, 1, 0), rotationAngle);
+	const Quaternion hand_position_axis_adjustment = rotationX * rotationY;
+	origin_from_hand_anchor_adjusted.basis = origin_from_hand_anchor_adjusted.basis * hand_position_axis_adjustment;
+	hand_tracker->set_pose("default", origin_from_hand_anchor_adjusted, Vector3(), Vector3());
+
+	// ARKit hand tracking doesn't have a palm joint, set it to hand anchor transform
+	BitField<XRHandTracker::HandJointFlags> flags = {};
+	flags.set_flag(XRHandTracker::HAND_JOINT_FLAG_ORIENTATION_VALID);
+	flags.set_flag(XRHandTracker::HAND_JOINT_FLAG_POSITION_VALID);
+	flags.set_flag(XRHandTracker::HAND_JOINT_FLAG_ORIENTATION_TRACKED);
+	flags.set_flag(XRHandTracker::HAND_JOINT_FLAG_POSITION_TRACKED);
+	hand_tracker->set_hand_joint_transform(XRHandTracker::HAND_JOINT_PALM, origin_from_hand_anchor_adjusted);
+	hand_tracker->set_hand_joint_flags(XRHandTracker::HAND_JOINT_PALM, flags);
+
+	// Set rest of joints
+	const Quaternion rotationZ(Vector3(0, 0, 1), rotationAngle);
+	const Quaternion joint_axis_adjustment = rotationX * rotationZ;
+	ar_hand_skeleton_enumerate_joints(hand_skeleton, ^bool(ar_skeleton_joint_t joint) {
+		uint64_t joint_index = ar_skeleton_joint_get_index(joint);
+		XRHandTracker::HandJoint hand_joint = joint_from_arkit((ar_hand_skeleton_joint_name_t)joint_index);
+		if (hand_joint == XRHandTracker::HAND_JOINT_MAX) {
+			return true;
+		}
+		simd_float4x4 hand_anchor_from_joint_simd = ar_skeleton_joint_get_anchor_from_joint_transform(joint);
+		Transform3D hand_anchor_from_joint = MTL::simd_to_transform3D(hand_anchor_from_joint_simd);
+		Transform3D origin_from_joint = origin_from_hand_anchor * hand_anchor_from_joint;
+		origin_from_joint.basis = origin_from_joint.basis * joint_axis_adjustment;
+		hand_tracker->set_hand_joint_transform(hand_joint, origin_from_joint);
+		hand_tracker->set_hand_joint_flags(hand_joint, flags);
+		return true;
+	});
+
+	hand_tracker->set_hand_tracking_source(XRHandTracker::HAND_TRACKING_SOURCE_UNOBSTRUCTED);
+	hand_tracker->set_has_tracking_data(true);
+}
+
+void VisionOSXRHandTracker::update_hand_trackers_from_arkit() {
+	if (!initialized) {
+		return;
+	}
+	// This can be used together with the visionOS XR interface, or on its own
+	CFTimeInterval trackable_anchor_time = 0;
+	if (xr_interface != nullptr && xr_interface->is_initialized()) {
+		// If it's used with the visionOS XR interface, process() on that interface must be called before this
+		// so the current_predicted_timing is obtained. XR interfaces run process() in alphabetical
+		// order ("visionOS" < "visionOSHandTracker"), so this constraint is satisfied.
+		cp_frame_timing_t frame_timing = xr_interface->get_current_timing();
+		if (frame_timing != nullptr) {
+			trackable_anchor_time = cp_time_to_cf_time_interval(cp_frame_timing_get_trackable_anchor_time(frame_timing));
+		}
+	} else {
+		// If it's used standalone, we obtain the estimatedPresentationTime from the active UIScene
+		UIWindowScene *windowScene = nil;
+		for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+			if ([scene isKindOfClass:[UIWindowScene class]]) {
+				UIWindowScene *windowSceneCandidate = (UIWindowScene *)scene;
+				if (windowSceneCandidate.activationState == UISceneActivationStateForegroundActive) {
+					windowScene = windowSceneCandidate;
+					break;
+				}
+			}
+		}
+		if (windowScene != nil) {
+			UIUpdateInfo *ui_update_info = [UIUpdateInfo currentUpdateInfoForWindowScene:windowScene];
+			trackable_anchor_time = ui_update_info.estimatedPresentationTime;
+		}
+	}
+
+	if (trackable_anchor_time != 0) {
+		ar_hand_anchor_query_status_t query_anchor_result =
+				ar_hand_tracking_provider_query_anchors_at_timestamp(hand_tracking_provider,
+						trackable_anchor_time,
+						left_hand_anchor,
+						right_hand_anchor);
+
+		if (query_anchor_result != ar_hand_anchor_query_status_success) {
+			tracking_state = XRInterface::XR_NOT_TRACKING;
+			reset_hand_tracker_data(left_hand_tracker);
+			reset_hand_tracker_data(right_hand_tracker);
+			ERR_FAIL_MSG("cannot query hand anchors, result: " + itos(query_anchor_result));
+		}
+	} else {
+		// If we failed to get a trackable_anchor_time, we just get the latest anchors.
+		// Tracking will be less precise in this case
+		bool result = ar_hand_tracking_provider_get_latest_anchors(hand_tracking_provider, left_hand_anchor, right_hand_anchor);
+		if (!result) {
+			tracking_state = XRInterface::XR_NOT_TRACKING;
+			reset_hand_tracker_data(left_hand_tracker);
+			reset_hand_tracker_data(right_hand_tracker);
+			ERR_FAIL_MSG("cannot query latest anchors, probably the ARKit session is not running");
+		}
+	}
+
+	tracking_state = XRInterface::XR_NORMAL_TRACKING;
+
+	if (ar_hand_anchor_is_tracked(left_hand_anchor)) {
+		set_hand_tracker_data_from_arkit(left_hand_tracker, left_hand_anchor);
+	} else {
+		reset_hand_tracker_data(left_hand_tracker);
+	}
+
+	if (ar_hand_anchor_is_tracked(right_hand_anchor)) {
+		set_hand_tracker_data_from_arkit(right_hand_tracker, right_hand_anchor);
+	} else {
+		reset_hand_tracker_data(right_hand_tracker);
+	}
+}
+
+void VisionOSXRHandTracker::process() {
+	if (!initialized) {
+		return;
+	}
+	update_hand_trackers_from_arkit();
+}
+
+Vector<RenderingServerTypes::BlitToScreen> VisionOSXRHandTracker::post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) {
+	_THREAD_SAFE_METHOD_
+	// We're overriding the color and depth textures, no need for screen blits
+	return Vector<RenderingServerTypes::BlitToScreen>();
+}
+
+#endif // VISIONOS_ENABLED

--- a/modules/visionos_xr/visionos_xr_interface.h
+++ b/modules/visionos_xr/visionos_xr_interface.h
@@ -50,13 +50,17 @@
 #else
 // When compiling as C++, use forward declarations for ARKit and CompositorServices types (opaque pointers)
 typedef struct ar_world_tracking_provider *ar_world_tracking_provider_t;
+typedef struct ar_data_provider *ar_data_provider_t;
 typedef struct cp_layer_renderer *cp_layer_renderer_t;
 typedef struct cp_layer_renderer_capabilities *cp_layer_renderer_capabilities_t;
 typedef struct ar_session *ar_session_t;
 typedef struct ar_device_anchor *ar_device_anchor_t;
 typedef struct cp_frame *cp_frame_t;
 typedef struct cp_drawable *cp_drawable_t;
+typedef struct cp_frame_timing *cp_frame_timing_t;
 #endif
+
+#include <os/lock.h>
 
 class VisionOSXRInterface : public XRInterface {
 	GDCLASS(VisionOSXRInterface, XRInterface);
@@ -80,10 +84,17 @@ private:
 
 	cp_layer_renderer_t layer_renderer = nullptr;
 	cp_layer_renderer_capabilities_t layer_renderer_capabilities = nullptr;
+
+	// Shared ARKit session (created lazily via ensure_session() from initialize(), used by trackers)
 	ar_session_t ar_session = nullptr;
+	// Stored as void* to avoid ARC issues with ObjC pointers in Godot's Vector<> template
+	Vector<void *> registered_data_providers;
+	os_unfair_lock session_lock = OS_UNFAIR_LOCK_INIT;
+	void rerun_session();
 
 	ar_device_anchor_t current_device_anchor = nullptr;
 	cp_frame_t current_frame = nullptr;
+	cp_frame_timing_t current_timing = nullptr;
 
 	// Data and functions only accessible from the rendering thread
 	class RenderThread : public Object {
@@ -164,6 +175,15 @@ public:
 
 	VisionOSXRInterface();
 	~VisionOSXRInterface();
+
+	// Shared ARKit session management
+	void ensure_session();
+	void destroy_session();
+	ar_session_t get_ar_session() const;
+	void add_data_provider(ar_data_provider_t p_provider);
+	void remove_data_provider(ar_data_provider_t p_provider);
+
+	cp_frame_timing_t get_current_timing();
 
 	void emit_signal_enum(SignalEnum p_signal);
 

--- a/modules/visionos_xr/visionos_xr_interface.mm
+++ b/modules/visionos_xr/visionos_xr_interface.mm
@@ -32,6 +32,7 @@
 
 #include "visionos_xr_interface.h"
 
+#include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
@@ -44,6 +45,8 @@
 #include "servers/rendering/rendering_server_types.h"
 
 #include "modules/visionos_xr/visionos_simd_helpers.h"
+#include "modules/visionos_xr/visionos_xr_controller_tracker.h"
+#include "modules/visionos_xr/visionos_xr_hand_tracker.h"
 #include "platform/visionos/godot_app_delegate_service_visionos.h"
 
 #import <ARKit/ARKit.h>
@@ -96,6 +99,58 @@ VisionOSXRInterface::~VisionOSXRInterface() {
 	}
 }
 
+// Shared ARKit session management
+
+void VisionOSXRInterface::ensure_session() {
+	os_unfair_lock_lock(&session_lock);
+	if (ar_session == nullptr) {
+		ar_session = ar_session_create();
+	}
+	os_unfair_lock_unlock(&session_lock);
+}
+
+void VisionOSXRInterface::destroy_session() {
+	os_unfair_lock_lock(&session_lock);
+	registered_data_providers.clear();
+	ar_session = nullptr;
+	os_unfair_lock_unlock(&session_lock);
+}
+
+ar_session_t VisionOSXRInterface::get_ar_session() const {
+	return ar_session;
+}
+
+void VisionOSXRInterface::add_data_provider(ar_data_provider_t p_provider) {
+	os_unfair_lock_lock(&session_lock);
+	registered_data_providers.push_back((__bridge void *)p_provider);
+	rerun_session();
+	os_unfair_lock_unlock(&session_lock);
+}
+
+void VisionOSXRInterface::remove_data_provider(ar_data_provider_t p_provider) {
+	os_unfair_lock_lock(&session_lock);
+	int64_t index = registered_data_providers.find((__bridge void *)p_provider);
+	if (index >= 0) {
+		registered_data_providers.remove_at(index);
+		rerun_session();
+	}
+	os_unfair_lock_unlock(&session_lock);
+}
+
+void VisionOSXRInterface::rerun_session() {
+	// Must be called with session_lock held.
+	ERR_FAIL_NULL(ar_session);
+	ar_data_providers_t data_providers = ar_data_providers_create();
+	for (int i = 0; i < registered_data_providers.size(); i++) {
+		ar_data_providers_add_data_provider(data_providers, (__bridge ar_data_provider_t)registered_data_providers[i]);
+	}
+	ar_session_run(ar_session, data_providers);
+}
+
+cp_frame_timing_t VisionOSXRInterface::get_current_timing() {
+	return current_timing;
+}
+
 StringName VisionOSXRInterface::get_name() const {
 	return VisionOSXRInterface::name;
 }
@@ -109,7 +164,7 @@ XRInterface::TrackingStatus VisionOSXRInterface::get_tracking_status() const {
 }
 
 bool VisionOSXRInterface::is_initialized() const {
-	return (initialized);
+	return initialized;
 }
 
 bool VisionOSXRInterface::initialize() {
@@ -130,14 +185,13 @@ bool VisionOSXRInterface::initialize() {
 	ERR_FAIL_NULL_V_MSG(layer_renderer, false, "GDTAppDelegateServiceVisionOS.layerRenderer not set");
 	ERR_FAIL_NULL_V_MSG(layer_renderer_capabilities, false, "GDTAppDelegateServiceVisionOS.layerRendererCapabilities not set");
 
-	// ARKit session initialization
-	ar_session = ar_session_create();
+	// ARKit session initialization (idempotent; lets this interface be initialized
+	// independently from GDScript without relying on the module registration order)
+	ensure_session();
 	ar_world_tracking_configuration_t world_tracking_configuration = ar_world_tracking_configuration_create();
 	world_tracking_provider = ar_world_tracking_provider_create(world_tracking_configuration);
 	current_device_anchor = ar_device_anchor_create();
-	ar_data_providers_t data_providers = ar_data_providers_create();
-	ar_data_providers_add_data_provider(data_providers, world_tracking_provider);
-	ar_session_run(ar_session, data_providers);
+	add_data_provider(world_tracking_provider);
 
 	// Head tracker initialization
 	head_tracker.instantiate();
@@ -158,12 +212,45 @@ bool VisionOSXRInterface::initialize() {
 	xr_server->set_primary_interface(this);
 
 	initialized = true;
+
+	// Initialize the trackers that are enabled via project settings. They can also be
+	// initialized independently from GDScript; initialize() guards against double-init.
+	if (GLOBAL_GET("xr/visionos/enable_hand_tracking")) {
+		Ref<VisionOSXRHandTracker> hand_tracker = VisionOSXRHandTracker::find_interface();
+		if (hand_tracker.is_valid()) {
+			hand_tracker->initialize();
+		}
+	}
+	if (GLOBAL_GET("xr/visionos/enable_controller_tracking")) {
+		Ref<VisionOSXRControllerTracker> controller_tracker = VisionOSXRControllerTracker::find_interface();
+		if (controller_tracker.is_valid()) {
+			controller_tracker->initialize();
+		}
+	}
+
 	return initialized;
 }
 
 void VisionOSXRInterface::uninitialize() {
 	if (!initialized) {
 		return;
+	}
+
+	// Tear down the trackers (reverse of initialize order). Each tracker's uninitialize()
+	// is a no-op if it was never initialized.
+	Ref<VisionOSXRControllerTracker> controller_tracker = VisionOSXRControllerTracker::find_interface();
+	if (controller_tracker.is_valid()) {
+		controller_tracker->uninitialize();
+	}
+	Ref<VisionOSXRHandTracker> hand_tracker = VisionOSXRHandTracker::find_interface();
+	if (hand_tracker.is_valid()) {
+		hand_tracker->uninitialize();
+	}
+
+	// Remove our world tracking provider from the shared session
+	if (world_tracking_provider != nullptr) {
+		remove_data_provider(world_tracking_provider);
+		world_tracking_provider = nullptr;
 	}
 
 	rendering_server->call_on_render_thread(callable_mp(&rt, &RenderThread::uninitialize));
@@ -245,9 +332,9 @@ bool VisionOSXRInterface::set_play_area_mode(XRInterface::PlayAreaMode p_mode) {
 void VisionOSXRInterface::set_head_pose_from_arkit() {
 	ERR_FAIL_NULL_MSG(current_frame, "Current frame is nil, process() has probably not been called, using identity transform.");
 
-	cp_frame_timing_t frame_timing = cp_frame_predict_timing(current_frame);
+	current_timing = cp_frame_predict_timing(current_frame);
 
-	CFTimeInterval presentation_time = cp_time_to_cf_time_interval(cp_frame_timing_get_presentation_time(frame_timing));
+	CFTimeInterval presentation_time = cp_time_to_cf_time_interval(cp_frame_timing_get_presentation_time(current_timing));
 	ar_device_anchor_query_status_t query_anchor_result = ar_world_tracking_provider_query_device_anchor_at_timestamp(world_tracking_provider, presentation_time, current_device_anchor);
 
 	if (query_anchor_result != ar_device_anchor_query_status_success) {

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -333,6 +333,14 @@ String EditorExportPlatformIOS::_process_config_file_line(const Ref<EditorExport
 	} else if (p_line.contains("$application_scene_manifest_immersive_configuration")) {
 		strnew += p_line.replace("$application_scene_manifest_immersive_configuration", "") + "\n";
 
+		// Info.plist NSHandsTrackingUsageDescription
+	} else if (p_line.contains("$hand_tracking_usage_description")) {
+		strnew += p_line.replace("$hand_tracking_usage_description", "") + "\n";
+
+		// Info.plist NSAccessoryTrackingUsageDescription
+	} else if (p_line.contains("$accessory_tracking_usage_description")) {
+		strnew += p_line.replace("$accessory_tracking_usage_description", "") + "\n";
+
 		// Apple Embedded common
 	} else {
 		strnew += EditorExportPlatformAppleEmbedded::_process_config_file_line(p_preset, p_line, p_config, p_debug, p_code_signing);

--- a/platform/visionos/export/export_plugin.cpp
+++ b/platform/visionos/export/export_plugin.cpp
@@ -274,6 +274,35 @@ String EditorExportPlatformVisionOS::_process_config_file_line(const Ref<EditorE
 
 		strnew += p_line.replace("$application_scene_manifest_immersive_configuration", value) + "\n";
 
+		// Info.plist NSHandsTrackingUsageDescription
+	} else if (p_line.contains("$hand_tracking_usage_description")) {
+		if (GLOBAL_GET("xr/visionos/enable_hand_tracking")) {
+			String value =
+					"<key>NSHandsTrackingUsageDescription</key>\n"
+					"<string>Used by the visionOS XR hand tracker interface to populate Godot's hand trackers.</string>";
+			strnew += p_line.replace("$hand_tracking_usage_description", value) + "\n";
+		} else {
+			strnew += p_line.replace("$hand_tracking_usage_description", "") + "\n";
+		}
+
+		// Info.plist NSAccessoryTrackingUsageDescription
+	} else if (p_line.contains("$accessory_tracking_usage_description")) {
+		if (GLOBAL_GET("xr/visionos/enable_controller_tracking")) {
+			String value =
+					"<key>NSAccessoryTrackingUsageDescription</key>\n"
+					"<string>Used by the visionOS XR controller tracker interface to populate Godot's controller trackers.</string>\n"
+					"<key>GCSupportedGameControllers</key>\n"
+					"<array>\n"
+					"    <dict>\n"
+					"        <key>ProfileName</key>\n"
+					"        <string>SpatialGamepad</string>\n"
+					"    </dict>\n"
+					"</array>";
+			strnew += p_line.replace("$accessory_tracking_usage_description", value) + "\n";
+		} else {
+			strnew += p_line.replace("$accessory_tracking_usage_description", "") + "\n";
+		}
+
 		// Apple Embedded common
 	} else {
 		strnew += EditorExportPlatformAppleEmbedded::_process_config_file_line(p_preset, p_line, p_config, p_debug, p_code_signing);

--- a/scene/3d/xr/xr_hand_modifier_3d.cpp
+++ b/scene/3d/xr/xr_hand_modifier_3d.cpp
@@ -293,8 +293,8 @@ PackedStringArray XRHandModifier3D::get_configuration_warnings() const {
 	PackedStringArray warnings = SkeletonModifier3D::get_configuration_warnings();
 
 	// Detect OpenXR without the Hand Tracking extension.
-	if (GLOBAL_GET("xr/openxr/enabled") && !GLOBAL_GET("xr/openxr/extensions/hand_tracking")) {
-		warnings.push_back("XRHandModifier3D requires the OpenXR Hand Tracking extension to be enabled.");
+	if (GLOBAL_GET("xr/openxr/enabled") && !GLOBAL_GET("xr/openxr/extensions/hand_tracking") && !GLOBAL_GET("xr/visionos/enable_hand_tracking")) {
+		warnings.push_back("XRHandModifier3D requires the OpenXR Hand Tracking extension or the visionOS hand tracker interface to be enabled.");
 	}
 
 	return warnings;


### PR DESCRIPTION
Dear Godot Community,

We are contributing visionOS support in https://github.com/godotengine/godot/pull/109975.

This follow-up implements hand and PSVR2 controller tracker interfaces. They live inside the visionOS XR module folder, but operate as separate XR Interfaces sharing a single ARKit session. If them being embedded inside the main visionXR Interface is preferred, we can perform that refactor.

_Disclaimer: Claude Code was used to assist development and to refactor code. All the code was reviewed by Apple employees, and tested on real hardware before submitting._