### PR TITLE
visionOS XR module – (5) visionOS: Spatial pinch input support via new InputEventSpatial event

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -85,8 +85,6 @@ class DisplayServerAppleEmbedded : public DisplayServer {
 
 	int virtual_keyboard_height = 0;
 
-	void perform_event(const Ref<InputEvent> &p_event);
-
 	void initialize_tts() const;
 
 	bool edr_requested = false;
@@ -101,6 +99,8 @@ protected:
 
 	DisplayServerAppleEmbedded(const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, DisplayServerEnums::Context p_context, int64_t p_parent_window, Error &r_error);
 	~DisplayServerAppleEmbedded();
+
+	void perform_event(const Ref<InputEvent> &p_event);
 
 public:
 	String rendering_driver;

--- a/platform/visionos/api/api.cpp
+++ b/platform/visionos/api/api.cpp
@@ -32,7 +32,12 @@
 
 #if defined(VISIONOS_ENABLED)
 
+#include "core/object/class_db.h"
+
+#include "platform/visionos/input_event_spatial.h"
+
 void register_visionos_api() {
+	GDREGISTER_CLASS(InputEventSpatial);
 	godot_apple_embedded_plugins_initialize();
 }
 

--- a/platform/visionos/app_visionos.swift
+++ b/platform/visionos/app_visionos.swift
@@ -30,6 +30,13 @@
 
 import SwiftUI
 @preconcurrency import CompositorServices
+import OSLog
+
+// MARK: Helpers
+
+extension os.Logger {
+	static let godot = Logger(subsystem: "com.GodotFoundation.Godot", category: "SwiftUI")
+}
 
 // MARK: Renderer
 
@@ -92,6 +99,33 @@ struct CompositorServicesImmersiveSpace: Scene {
 	var body: some Scene {
 		ImmersiveSpace(id: "ImmersiveSpace") {
 			CompositorLayer(configuration: ContentStageConfiguration()) { @MainActor layerRenderer in
+
+				layerRenderer.onSpatialEvent = { spatialEventCollection in
+					for event in spatialEventCollection {
+						guard event.kind == .indirectPinch else {
+							Logger.godot.log("Ignoring non-IndirectPinch event: \(String(describing: event))")
+							return
+						}
+						guard let selectionRay = event.selectionRay else {
+							Logger.godot.log("Ignoring event without selectionRay: \(String(describing: event))")
+							return
+						}
+						guard let inputDevicePose = event.inputDevicePose else {
+							Logger.godot.log("Ignoring event without inputDevicePose: \(String(describing: event))")
+							return
+						}
+						let isActive = (event.phase == .active)
+						let hasBeenCancelled = (event.phase == .cancelled)
+						renderer.spatialEvent(with: event.id.hashValue,
+											  isActive: isActive,
+											  hasBeenCancelled: hasBeenCancelled,
+											  hasChirality: event.chirality != nil,
+											  isLeftHand: event.chirality == .left,
+											  selectionRay: selectionRay,
+											  inputDevicePose: inputDevicePose.pose3D)
+					}
+				}
+
 				GDTAppDelegateServiceVisionOS.layerRenderer = layerRenderer
 				renderer = GDTCompositorServicesRenderer(layerRenderer: layerRenderer,
                                                          capabilities: GDTAppDelegateServiceVisionOS.layerRendererCapabilities)

--- a/platform/visionos/display_server_visionos.h
+++ b/platform/visionos/display_server_visionos.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "input_event_spatial.h"
+
 #include "drivers/apple_embedded/display_server_apple_embedded.h"
 
 class GCKeyboardHandler;
@@ -55,6 +57,15 @@ public:
 	virtual int screen_get_dpi(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_scale(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_refresh_rate(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+
+	void spatial_event(int p_index,
+			InputEventSpatial::Phase p_phase,
+			bool p_has_chirality,
+			InputEventSpatial::Chirality p_chirality,
+			const Vector3 &p_selection_ray_origin,
+			const Vector3 &p_selection_ray_direction,
+			const Vector3 &p_input_device_pose_position,
+			const Quaternion &p_input_device_pose_rotation);
 
 protected:
 	virtual bool _screen_hdr_is_supported() const override;

--- a/platform/visionos/display_server_visionos.mm
+++ b/platform/visionos/display_server_visionos.mm
@@ -31,6 +31,7 @@
 #import "display_server_visionos.h"
 
 #import "gc_keyboard_handler.h"
+#include "input_event_spatial.h"
 
 #include "core/os/os.h"
 
@@ -99,6 +100,31 @@ float DisplayServerVisionOS::screen_get_scale(int p_screen) const {
 	ERR_FAIL_INDEX_V(p_screen, screen_count, 1.0f);
 
 	return 1;
+}
+
+void DisplayServerVisionOS::spatial_event(int p_index,
+		InputEventSpatial::Phase p_phase,
+		bool p_has_chirality,
+		InputEventSpatial::Chirality p_chirality,
+		const Vector3 &p_selection_ray_origin,
+		const Vector3 &p_selection_ray_direction,
+		const Vector3 &p_input_device_pose_position,
+		const Quaternion &p_input_device_pose_rotation) {
+	Ref<InputEventSpatial> ev;
+	ev.instantiate();
+
+	ev->set_index(p_index);
+	ev->set_phase(p_phase);
+	if (p_has_chirality) {
+		ev->set_flag(InputEventSpatial::FLAG_HAS_CHIRALITY, true);
+		ev->set_chirality(p_chirality);
+	}
+	ev->set_flag(InputEventSpatial::FLAG_HAS_SELECTION_RAY, true);
+	ev->set_selection_ray_origin(p_selection_ray_origin);
+	ev->set_selection_ray_direction(p_selection_ray_direction);
+	ev->set_input_device_pose_position(p_input_device_pose_position);
+	ev->set_input_device_pose_rotation(p_input_device_pose_rotation);
+	perform_event(ev);
 }
 
 bool DisplayServerVisionOS::_screen_hdr_is_supported() const {

--- a/platform/visionos/godot_compositor_services_renderer.h
+++ b/platform/visionos/godot_compositor_services_renderer.h
@@ -33,6 +33,7 @@
 #import "drivers/apple_embedded/godot_renderer.h"
 
 #import <CompositorServices/CompositorServices.h>
+#import <Spatial/Spatial.h>
 
 @interface GDTCompositorServicesRenderer : GDTRenderer
 
@@ -43,6 +44,14 @@
 
 - (void)startRenderLoop;
 - (void)renderFrame;
+
 - (void)worldRecentered;
+- (void)spatialEventWithIndex:(NSInteger)index
+					 isActive:(BOOL)isActive
+			 hasBeenCancelled:(BOOL)hasBeenCancelled
+				 hasChirality:(BOOL)hasChirality
+				   isLeftHand:(BOOL)isLeftHand
+				 selectionRay:(SPRay3D)selectionRay
+			  inputDevicePose:(SPPose3D)inputDevicePose;
 
 @end

--- a/platform/visionos/godot_compositor_services_renderer.mm
+++ b/platform/visionos/godot_compositor_services_renderer.mm
@@ -30,7 +30,11 @@
 
 #import "godot_compositor_services_renderer.h"
 
-#import "drivers/apple_embedded/os_apple_embedded.h"
+#include "display_server_visionos.h"
+#include "input_event_spatial.h"
+
+#include "drivers/apple_embedded/os_apple_embedded.h"
+#include "servers/rendering/rendering_server_default.h"
 
 #include "modules/visionos_xr/visionos_xr_interface.h"
 
@@ -117,6 +121,23 @@ extern void apple_embedded_finish();
 	if (visionos_xr_interface.is_valid()) {
 		visionos_xr_interface->emit_signal_enum(VisionOSXRInterface::VISIONOS_XR_SIGNAL_POSE_RECENTERED);
 	}
+}
+
+- (void)spatialEventWithIndex:(NSInteger)index
+					 isActive:(BOOL)isActive
+			 hasBeenCancelled:(BOOL)hasBeenCancelled
+				 hasChirality:(BOOL)hasChirality
+				   isLeftHand:(BOOL)isLeftHand
+				 selectionRay:(SPRay3D)selectionRay
+			  inputDevicePose:(SPPose3D)inputDevicePose {
+	Vector3 selectionRayOrigin(selectionRay.origin.x, selectionRay.origin.y, selectionRay.origin.z);
+	Vector3 selectionRayDirection(selectionRay.direction.x, selectionRay.direction.y, selectionRay.direction.z);
+	InputEventSpatial::Chirality chirality = isLeftHand ? InputEventSpatial::CHIRALITY_LEFT : InputEventSpatial::CHIRALITY_RIGHT;
+	InputEventSpatial::Phase phase = isActive ? InputEventSpatial::PHASE_ACTIVE : (hasBeenCancelled ? InputEventSpatial::PHASE_CANCELLED : InputEventSpatial::PHASE_ENDED);
+	simd_double4 deviceInputRotationQuat = inputDevicePose.rotation.quaternion.vector;
+	Vector3 inputDevicePosition(inputDevicePose.position.x, inputDevicePose.position.y, inputDevicePose.position.z);
+	Quaternion inputDeviceRotation(deviceInputRotationQuat[0], deviceInputRotationQuat[1], deviceInputRotationQuat[2], deviceInputRotationQuat[3]);
+	DisplayServerVisionOS::get_singleton()->spatial_event(index, phase, hasChirality, chirality, selectionRayOrigin, selectionRayDirection, inputDevicePosition, inputDeviceRotation);
 }
 
 @end

--- a/platform/visionos/input_event_spatial.h
+++ b/platform/visionos/input_event_spatial.h
@@ -1,0 +1,110 @@
+/**************************************************************************/
+/*  input_event_spatial.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/input/input_event.h"
+
+class InputEventSpatial : public InputEventFromWindow {
+	GDCLASS(InputEventSpatial, InputEventFromWindow)
+protected:
+	static void _bind_methods();
+
+public:
+	enum Flags {
+		FLAG_HAS_CHIRALITY,
+		FLAG_HAS_SELECTION_RAY,
+		FLAG_MAX,
+	};
+
+	enum Chirality {
+		CHIRALITY_LEFT,
+		CHIRALITY_RIGHT,
+	};
+
+	enum Phase {
+		PHASE_ACTIVE,
+		PHASE_CANCELLED,
+		PHASE_ENDED,
+	};
+
+	bool get_flag(Flags p_flag) const { return flags[uint32_t(p_flag)]; }
+	void set_flag(Flags p_flag, bool p_value) { flags[uint32_t(p_flag)] = p_value; }
+
+	void set_index(int p_index) { index = p_index; }
+	int get_index() const { return index; }
+
+	Phase get_phase() const { return phase; }
+	void set_phase(Phase p_phase) { phase = p_phase; }
+
+	Chirality get_chirality() const { return chirality; }
+	void set_chirality(Chirality p_chirality) { chirality = p_chirality; }
+
+	Vector3 get_selection_ray_origin() const { return selection_ray_origin; }
+	void set_selection_ray_origin(const Vector3 &p_selection_ray_origin) {
+		selection_ray_origin = p_selection_ray_origin;
+	}
+
+	Vector3 get_selection_ray_direction() const { return selection_ray_direction; }
+	void set_selection_ray_direction(const Vector3 &p_selection_ray_direction) {
+		selection_ray_direction = p_selection_ray_direction;
+	}
+
+	Vector3 get_input_device_pose_position() const { return input_device_pose_position; }
+	void set_input_device_pose_position(const Vector3 &p_input_device_pose_position) {
+		input_device_pose_position = p_input_device_pose_position;
+	}
+
+	Quaternion get_input_device_pose_rotation() const { return input_device_pose_rotation; }
+	void set_input_device_pose_rotation(const Quaternion &p_input_device_pose_rotation) {
+		input_device_pose_rotation = p_input_device_pose_rotation;
+	}
+
+	virtual String as_text() const override;
+	virtual String _to_string() override;
+
+private:
+	int index = 0;
+
+	Phase phase = PHASE_ACTIVE;
+	Chirality chirality = CHIRALITY_LEFT;
+
+	Vector3 selection_ray_origin;
+	Vector3 selection_ray_direction;
+
+	Vector3 input_device_pose_position;
+	Quaternion input_device_pose_rotation;
+
+	bool flags[FLAG_MAX] = {};
+};
+
+VARIANT_ENUM_CAST(InputEventSpatial::Flags);
+VARIANT_ENUM_CAST(InputEventSpatial::Phase);
+VARIANT_ENUM_CAST(InputEventSpatial::Chirality);

--- a/platform/visionos/input_event_spatial.mm
+++ b/platform/visionos/input_event_spatial.mm
@@ -1,0 +1,122 @@
+/**************************************************************************/
+/*  input_event_spatial.mm                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "input_event_spatial.h"
+
+#include "core/object/class_db.h"
+
+void InputEventSpatial::_bind_methods() {
+	BIND_ENUM_CONSTANT(FLAG_HAS_CHIRALITY);
+	BIND_ENUM_CONSTANT(FLAG_HAS_SELECTION_RAY);
+	BIND_ENUM_CONSTANT(FLAG_MAX);
+
+	BIND_ENUM_CONSTANT(CHIRALITY_LEFT);
+	BIND_ENUM_CONSTANT(CHIRALITY_RIGHT);
+
+	BIND_ENUM_CONSTANT(PHASE_ACTIVE);
+	BIND_ENUM_CONSTANT(PHASE_CANCELLED);
+	BIND_ENUM_CONSTANT(PHASE_ENDED);
+
+	ClassDB::bind_method(D_METHOD("set_index", "index"), &InputEventSpatial::set_index);
+	ClassDB::bind_method(D_METHOD("get_index"), &InputEventSpatial::get_index);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "index"), "set_index", "get_index");
+
+	ClassDB::bind_method(D_METHOD("set_phase", "phase"), &InputEventSpatial::set_phase);
+	ClassDB::bind_method(D_METHOD("get_phase"), &InputEventSpatial::get_phase);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "phase"), "set_phase", "get_phase");
+
+	ClassDB::bind_method(D_METHOD("get_flag", "flag"), &InputEventSpatial::get_flag);
+	ClassDB::bind_method(D_METHOD("set_flag", "flag", "value"), &InputEventSpatial::set_flag);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "has_chirality"), "set_flag", "get_flag", FLAG_HAS_CHIRALITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "has_selection_ray"), "set_flag", "get_flag", FLAG_HAS_SELECTION_RAY);
+
+	ClassDB::bind_method(D_METHOD("get_chirality"), &InputEventSpatial::get_chirality);
+	ClassDB::bind_method(D_METHOD("set_chirality", "chirality"), &InputEventSpatial::set_chirality);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "chirality"), "set_chirality", "get_chirality");
+
+	ClassDB::bind_method(D_METHOD("get_selection_ray_origin"), &InputEventSpatial::get_selection_ray_origin);
+	ClassDB::bind_method(D_METHOD("set_selection_ray_origin", "selection_ray_origin"), &InputEventSpatial::set_selection_ray_origin);
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "selection_ray_origin"), "set_selection_ray_origin", "get_selection_ray_origin");
+
+	ClassDB::bind_method(D_METHOD("get_selection_ray_direction"), &InputEventSpatial::get_selection_ray_direction);
+	ClassDB::bind_method(D_METHOD("set_selection_ray_direction", "selection_ray_direction"), &InputEventSpatial::set_selection_ray_direction);
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "selection_ray_direction"), "set_selection_ray_direction", "get_selection_ray_direction");
+
+	ClassDB::bind_method(D_METHOD("get_input_device_pose_position"), &InputEventSpatial::get_input_device_pose_position);
+	ClassDB::bind_method(D_METHOD("set_input_device_pose_position", "input_device_pose_position"), &InputEventSpatial::set_input_device_pose_position);
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "input_device_pose_position"), "set_input_device_pose_position", "get_input_device_pose_position");
+
+	ClassDB::bind_method(D_METHOD("get_input_device_pose_rotation"), &InputEventSpatial::get_input_device_pose_rotation);
+	ClassDB::bind_method(D_METHOD("set_input_device_pose_rotation", "input_device_pose_rotation"), &InputEventSpatial::set_input_device_pose_rotation);
+	ADD_PROPERTY(PropertyInfo(Variant::QUATERNION, "input_device_pose_rotation"), "set_input_device_pose_rotation", "get_input_device_pose_rotation");
+}
+
+String InputEventSpatial::as_text() const {
+	String phase_text;
+	switch (phase) {
+		case PHASE_ACTIVE:
+			phase_text = RTR("active");
+			break;
+		case PHASE_CANCELLED:
+			phase_text = RTR("cancelled");
+			break;
+		case PHASE_ENDED:
+			phase_text = RTR("ended");
+			break;
+	}
+
+	String chirality_text = (chirality == CHIRALITY_LEFT) ? RTR("left") : RTR("right");
+
+	return vformat(RTR("Spatial event %s, %s hand, index %d"), phase_text, chirality_text, index);
+}
+
+String InputEventSpatial::_to_string() {
+	String phase_string;
+	switch (phase) {
+		case PHASE_ACTIVE:
+			phase_string = "PHASE_ACTIVE";
+			break;
+		case PHASE_CANCELLED:
+			phase_string = "PHASE_CANCELLED";
+			break;
+		case PHASE_ENDED:
+			phase_string = "PHASE_ENDED";
+			break;
+	}
+
+	String chirality_string = (chirality == CHIRALITY_LEFT) ? "CHIRALITY_LEFT" : "CHIRALITY_RIGHT";
+	String has_chirality = get_flag(FLAG_HAS_CHIRALITY) ? "true" : "false";
+	String has_selection_ray = get_flag(FLAG_HAS_SELECTION_RAY) ? "true" : "false";
+
+	return vformat("InputEventSpatial: index=%d, phase=%s, has_chirality=%s, chirality=%s, has_selection_ray=%s, selection_ray_origin=(%s), selection_ray_direction=(%s), input_device_position=(%s), input_device_rotation=(%s)",
+			index, phase_string, has_chirality, chirality_string, has_selection_ray,
+			String(selection_ray_origin), String(selection_ray_direction),
+			String(input_device_pose_position), String(input_device_pose_rotation));
+}


### PR DESCRIPTION
Dear Godot Community,

We are contributing visionOS support in https://github.com/godotengine/godot/pull/109975. This follow-up adds spatial pinch input support via a new `InputEventSpatial` event.

You can process and use it from GDScript to drive UI, or to drive interaction in your game.

Example:

```
func _unhandled_input(event):
	if is_instance_of(event, InputEventSpatial):
		print("visionOS XR: InputEventSpatial event", event.to_string())
```

Full example showing how to route interactions to UI in your Immersive Scene to follow later.

_Disclaimer: Claude Code was used to assist development and to refactor code. All the code was reviewed by Apple employees, and tested on real hardware before submitting._